### PR TITLE
[AwsSQSv3] Added support for mocked SQS server

### DIFF
--- a/src/Riverline/WorkerBundle/Provider/AwsSQSv3.php
+++ b/src/Riverline/WorkerBundle/Provider/AwsSQSv3.php
@@ -194,7 +194,7 @@ class AwsSQSv3 extends BaseProvider
 
                 $this->queueUrls[$queueName] = $response['QueueUrl'];
             } catch (SqsException $e) {
-                if ('AWS.SimpleQueueService.NonExistentQueue' === $e->getAwsErrorCode()) {
+                if (strpos($e->getAwsErrorCode(), 'NonExistentQueue') !== false) {
                     // Non existing queue
                     return null;
                 } else {


### PR DESCRIPTION
Change `NonExistentQueue` exception check to support mocked SQS servers like https://hub.docker.com/r/feathj/fake-sqs/ 