### PR TITLE
Solved call to undefined method

### DIFF
--- a/src/Riverline/WorkerBundle/Provider/AwsSQSv2.php
+++ b/src/Riverline/WorkerBundle/Provider/AwsSQSv2.php
@@ -194,7 +194,7 @@ class AwsSQSv2 extends BaseProvider
                 ));
                 $this->queueUrls[$queueName] = $response['QueueUrl'];
             } catch(SqsException $e) {
-                if ('AWS.SimpleQueueService.NonExistentQueue' === $e->getExceptionCode()) {
+                if ('AWS.SimpleQueueService.NonExistentQueue' === $e->getAwsErrorCode()) {
                     // Non existing queue
                     return null;
                 } else {


### PR DESCRIPTION
This PR solves an "Attempted to call an undefined method named getExceptionCode" when a non existing queue is configured. The provider still doesn't work, because it requires an existing queue, but an ``InvalidArgumentException`` is much better than a ``UndefinedMethodException``.