### PR TITLE
Fix warning thrown when using AmazonSQSv2 and AmazonSQSv3 with PHP 7.2.

### DIFF
--- a/src/Riverline/WorkerBundle/Provider/AwsSQSv2.php
+++ b/src/Riverline/WorkerBundle/Provider/AwsSQSv2.php
@@ -163,6 +163,10 @@ class AwsSQSv2 extends BaseProvider
         }
         $response = $this->sqs->receiveMessage($options);
 
+        if (is_null($response['Messages'])) {
+            return null;
+        }
+
         if (count($response['Messages']) > 0) {
             $workload = $response['Messages'][0];
 

--- a/src/Riverline/WorkerBundle/Provider/AwsSQSv3.php
+++ b/src/Riverline/WorkerBundle/Provider/AwsSQSv3.php
@@ -162,6 +162,10 @@ class AwsSQSv3 extends BaseProvider
         }
         $response = $this->sqs->receiveMessage($options);
 
+        if (is_null($response['Messages'])) {
+            return null;
+        }
+
         if (count($response['Messages']) > 0) {
             $workload = $response['Messages'][0];
 


### PR DESCRIPTION
Should fix #9.